### PR TITLE
Unify top level namespace

### DIFF
--- a/application/ui/todo/application.rb
+++ b/application/ui/todo/application.rb
@@ -1,4 +1,4 @@
-module ToDo
+module Todo
   class Application < Gtk::Application
     attr_reader :user_data_path
 

--- a/gtk-todo
+++ b/gtk-todo
@@ -25,5 +25,5 @@ at_exit do
   FileUtils.rm_f(resource_bin)
 end
 
-app = ToDo::Application.new
+app = Todo::Application.new
 puts app.run


### PR DESCRIPTION
As I can't see any reasons to set 2 top level namespaces (`Todo` and `ToDo`) I assume it's a typo…


Great tutorial by the way 😺 